### PR TITLE
Fix Castille not picking exploration ideas first.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 .cwtools/
+/.vs

--- a/common/buildings/vu_buildings.txt
+++ b/common/buildings/vu_buildings.txt
@@ -18,7 +18,7 @@
 # Transportation
 ################################################
 
-canal = {
+transport_canal = {
 	cost = 200
 	time = 12
 
@@ -33,10 +33,10 @@ canal = {
 			has_port = yes
 			AND = {
 				any_friendly_coast_border_province = {
-					has_building = canal
+					has_building = transport_canal
 				}
 				any_neighbor_province = {
-					has_building = canal
+					has_building = transport_canal
 				}
 			}
 		}	

--- a/common/ideas/00_basic_ideas.txt
+++ b/common/ideas/00_basic_ideas.txt
@@ -737,7 +737,7 @@ exploration_ideas = {
 			num_of_ports = 20
 		}
 		modifier = {
-			factor = 1000
+			factor = 100 # This is 1000 in the base game, but factor seems to become TOO large because of qty. of ports and CAS does not pick exploration.
 			OR = {
 				tag = POR
 				tag = CAS

--- a/common/technologies/adm.txt
+++ b/common/technologies/adm.txt
@@ -260,7 +260,7 @@ technology = { #Modern Bureaucracy
 	#Modern Canal System
     #Rotherham Plough
 	production_efficiency = 0.02
-	canal = yes
+	transport_canal = yes
 }
 
 technology = { #Rotherham Plough

--- a/interface/building_icons.gfx
+++ b/interface/building_icons.gfx
@@ -1031,42 +1031,42 @@ spriteTypes = {
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal"
+		name = "GFX_transport_canal"
 		texturefile = "gfx//interface//buildings//latin_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_easterngfx"
+		name = "GFX_transport_canal_easterngfx"
 		texturefile = "gfx//interface//buildings//eastern_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_asiangfx"
+		name = "GFX_transport_canal_asiangfx"
 		texturefile = "gfx//interface//buildings//chinese_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_africangfx"
+		name = "GFX_transport_canal_africangfx"
 		texturefile = "gfx//interface//buildings//african_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_indiangfx"
+		name = "GFX_transport_canal_indiangfx"
 		texturefile = "gfx//interface//buildings//indian_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_muslimgfx"
+		name = "GFX_transport_canal_muslimgfx"
 		texturefile = "gfx//interface//buildings//muslim_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_southamericagfx"
+		name = "GFX_transport_canal_southamericagfx"
 		texturefile = "gfx//interface//buildings//southamerica_canal.tga"
 		loadType = "INGAME"
 	}
 	spriteType = {
-		name = "GFX_canal_northamericagfx"
+		name = "GFX_transport_canal_northamericagfx"
 		texturefile = "gfx//interface//buildings//northamerica_canal.tga"
 		loadType = "INGAME"
 	}

--- a/interface/macrobuildinterface.gui
+++ b/interface/macrobuildinterface.gui
@@ -1345,13 +1345,13 @@ guiTypes = {
 		}
 		
 		checkboxType = {
-			name = "build_canal"
+			name = "build_transport_canal"
 			position = { x = 348 y = 517 }
 			quadTextureSprite = "GFX_courthouse_muslimgfx" #Placeholder, real sprite is decided by game (based on button name).
 		}
 
 		instantTextBoxType={
-			name = "canal_cost"
+			name = "transport_canal_cost"
 			position = {x = 348 y = 567 }
 			font = "vic_18"
 			borderSize = {x = 0 y = 0}

--- a/interface/provinceview.gui
+++ b/interface/provinceview.gui
@@ -6440,13 +6440,13 @@ guiTypes = {
 		}
 			
 		checkboxType = {
-			name = "build_canal"
+			name = "build_transport_canal"
 			position = { x = 320 y = 531 }
 			quadTextureSprite = "GFX_courthouse_muslimgfx" #Placeholder, real sprite is decided by game (based on button name).
 		}
 
 		instantTextBoxType={
-			name = "canal_cost"
+			name = "transport_canal_cost"
 			position = {x = 320 y = 582 }
 			font = "vic_18"
 			borderSize = {x = 0 y = 0}

--- a/localisation/replace/vu_changes_l_english.yml
+++ b/localisation/replace/vu_changes_l_english.yml
@@ -1809,7 +1809,7 @@
  #VIC_HEALTH_3:0 "(3) Your country provides Good National Health Care"
 
  #NEW BUILDINGS - Added in TCOP by San Felipe
- building_canal:0 "Canal"
+ building_transport_canal:0 "Canal"
  building_railroad:0 "Railroad"
  building_fort_19th:0 "Polygonal Fort"
  building_fort_siege_1:0 "Siege Weaponry: Field Howitzer"


### PR DESCRIPTION
Factor seems to have an overflow (?) in it somewhere between 10 and 11k, beyond which the idea group will not be picked. Castille had 12000 factor for exploration due to the number of ports they have in the mod (0.75*2*2*2*2*1000). 100 should still be enough for them to always pick exploration under normal circumstances.