### PR TITLE
Fixed changed province_id 1926 to 1 for Hansa trade node mission goal.

### DIFF
--- a/missions/EMP_Hansa_Missions.txt
+++ b/missions/EMP_Hansa_Missions.txt
@@ -425,11 +425,11 @@ hanseatic_sound_toll_tree = {
 		position = 2
 	
 		provinces_to_highlight = {
-			province_id = 1926 # Baltic Sea
+			province_id = 1 # Baltic Sea
 		}
 	
 		trigger = {
-			1926 = {
+			1 = {
 				trade_share = {
 					country = ROOT
 					share = 30


### PR DESCRIPTION
Fixed, changed province_id from 1926 to 1 for Hansa trade node mission goal.