### PR TITLE
Important fix to provinces file!

### DIFF
--- a/events/flavorPOL.txt
+++ b/events/flavorPOL.txt
@@ -1704,6 +1704,7 @@ country_event = {
 		ai_chance = { 
 			factor = 20
 		}
+		add_stability = 1
 		define_ruler = {
 			DIP = 4
 			ADM = 4
@@ -1846,7 +1847,6 @@ country_event = {
 			}
 		}
 	}
-}
 }
 
 # Become elective

--- a/history/provinces/8734 - Louth.txt
+++ b/history/provinces/8734 - Louth.txt
@@ -37,7 +37,6 @@ discovered_by = muslim
 discovered_by = ottoman
 discovered_by = eastern
 
-}
 
 1541.6.18 = {
 	owner = ANI


### PR DESCRIPTION
Important fix to provinces.bmp file. It might've caused game crash on load due to some errors while merging two map files. Noticed the error when file jumped to over 58MB of size. It's now back to its proper size, so I assume everything will be normal now.